### PR TITLE
Some syntax and spelling fixes

### DIFF
--- a/upgrade-arl-auto-app/ensuring_that_the_new_controllers_are_set_up_correctly.adoc
+++ b/upgrade-arl-auto-app/ensuring_that_the_new_controllers_are_set_up_correctly.adoc
@@ -131,7 +131,7 @@ See the link:https://docs.netapp.com/ontap-9/topic/com.netapp.doc.dot-cm-sag/hom
 
 .. Enter the following command:
 +
-`storage failover modify -node <node_name> - cifs- ndo-duration default|medium|low`
+`storage failover modify -node <node_name> -cifs-ndo-duration default|medium|low`
 +
 * Enter `medium` if the system will have workloads in which 50% to 75% of the operations will be 4 KB or smaller.
 * Enter `low` if the system will have workloads in which 75% to 100% of the operations will be 4 KB or smaller.

--- a/upgrade-arl-auto-app/installing_and_booting_node4.adoc
+++ b/upgrade-arl-auto-app/installing_and_booting_node4.adoc
@@ -194,15 +194,15 @@ Interrupt the autoboot by pressing Ctrl-C at the boot environment prompt.
 
 . If necessary, set the partner system ID on node4 by using the following command:
 +
-`setenv partner- sysid <node2_sysid>`
+`setenv partner-sysid <node2_sysid>`
 
 .. Save the settings:
 +
 `saveenv`
 
-. [[Step21]]On the new node, in boot loader, the `partner- sysid` parameter must be set. For node4, `partner- sysid` must be that of node3. Verify the `partner- sysid` for node3 by using the following command:
+. [[Step21]]On the new node, in boot loader, the `partner-sysid` parameter must be set. For node4, `partner-sysid` must be that of node3. Verify the `partner-sysid` for node3 by using the following command:
 +
-`printenv partner- sysid`
+`printenv partner-sysid`
 
 . Take one of the following actions:
 +

--- a/upgrade-arl-auto-app/setting_the_fc_or_uta_uta2_configuration_on_node3.adoc
+++ b/upgrade-arl-auto-app/setting_the_fc_or_uta_uta2_configuration_on_node3.adoc
@@ -445,9 +445,9 @@ NOTE: Failing to perform the previous substep might cause node3 to boot from the
 The following shows an example of the command output:
 +
 ....
-Aggr            State   Status    Options
-aggr 0_nst_fas  8080_15 online    raid_dp, aggr root,  nosnap=on
-                                  fast zeroed, 64-bit
-aggr            0       offline   raid_dp, aggr, diskroot
-                                  fast zeroed, 64-bit
+Aggr            State   Status              Options
+aggr0_fas8080_1 online  raid_dp, aggr       root, nosnap=on
+                        fast zeroed, 64-bit
+aggr0           offline raid_dp, aggr       diskroot
+                        fast zeroed, 64-bit
 ....

--- a/upgrade-arl-auto-app/setting_the_fc_or_uta_uta2_configuration_on_node3.adoc
+++ b/upgrade-arl-auto-app/setting_the_fc_or_uta_uta2_configuration_on_node3.adoc
@@ -426,7 +426,7 @@ The following procedure sets node3 to boot from the root aggregate of node1:
 
 .. If necessary, bring the node1 aggregate online by using the following command:
 +
-`aggr_online root_aggr_from_<node1>`
+`aggr online <root_aggr_from_node1>`
 
 .. Prevent the node3 from booting from its original root aggregate by using the following command:
 +
@@ -434,7 +434,7 @@ The following procedure sets node3 to boot from the root aggregate of node1:
 
 .. Set the node1 root aggregate as the new root aggregate for node3 by using the following command:
 +
-`aggr options aggr_from_<node1> root`
+`aggr options <aggr_from_node1> root`
 
 .. Verify that the root aggregate of node3 is offline and the root aggregate for the disks brought over from node1 is online and set to root by using the following command:
 +

--- a/upgrade-arl-auto-app/setting_the_fc_or_uta_uta2_configuration_on_node4.adoc
+++ b/upgrade-arl-auto-app/setting_the_fc_or_uta_uta2_configuration_on_node4.adoc
@@ -449,7 +449,7 @@ The following procedure sets node4 to boot from the root aggregate of node2:
 
 .. If necessary, bring the node2 aggregate online by using the following command:
 +
-`aggr_online root_aggr_from_<node2>`
+`aggr online <root_aggr_from_node2>`
 
 .. Prevent the node4 from booting from its original root aggregate by using the following command:
 +
@@ -457,7 +457,7 @@ The following procedure sets node4 to boot from the root aggregate of node2:
 
 .. Set the node2 root aggregate as the new root aggregate for node4 by using the following command:
 +
-`aggr options aggr_from_<node2> root`
+`aggr options <aggr_from_node2> root`
 
 .. Verify that the root aggregate of node4 is offline and the root aggregate for the disks brought over from node2 is online and set to root by using the following command:
 +
@@ -471,13 +471,13 @@ The following shows an example of the command output:
 +
 ....
 ---------------------------------------------------------------------
-Aggr State                       Status               Options
-aggr 0_nst_fas8080_15 online     raid_dp, aggr        root, nosnap=on
-                                 fast zeroed
-                                 64-bit
-aggr0 offline                    raid_dp, aggr        diskroot
-                                 fast zeroed`
-                                 64-bit
+Aggr            State     Status           Options
+aggr0_fas8080_1 online    raid_dp, aggr    root, nosnap=on
+                          fast zeroed
+                          64-bit
+aggr0           offline   raid_dp, aggr    diskroot
+                          fast zeroed`
+                          64-bit
 ---------------------------------------------------------------------
 ....
 // 11 DEC 2020, thomi, checked


### PR DESCRIPTION
`aggr_online` is not a command, it is  `aggr online`.

Also unify the placeholders for the aggregate names