### PR TITLE
Update pci_cards_and_risers_replace.adoc

### DIFF
--- a/fas9000/pci_cards_and_risers_replace.adoc
+++ b/fas9000/pci_cards_and_risers_replace.adoc
@@ -84,8 +84,8 @@ a|I/O cam latch completely unlocked
 After you replace a PCIe module, you must reboot the controller module.
 
 .Steps
-. If the node is at the LOADER prompt, boot the node, responding `y` if you see a prompt warning of a system ID mismatch and asking to override the system ID: `bye`
 . If your system is configured to support 10 GbE cluster interconnect and data connections on 40 GbE NICs or onboard ports, convert these ports to 10 GbE connections by using the `nicadmin convert` command from Maintenance mode.
+. Have the node at the LOADER prompt, make sure to boot the node using the following command: `bye`
 +
 NOTE: Be sure to exit Maintenance mode after completing the conversion.
 


### PR DESCRIPTION
I/O cards (outside of the NVRAM cards), won't prompt for SYSID changes.  (which is already a separate doc) - it's also very important for you to run the "BYE" command from LOADER to re-initialize the PCI bus.