### PR TITLE
Update pci_cards_and_risers_replace.adoc

### DIFF
--- a/a900/pci_cards_and_risers_replace.adoc
+++ b/a900/pci_cards_and_risers_replace.adoc
@@ -79,13 +79,14 @@ I/O cam latch completely unlocked
 . Install the replacement I/O module into the chassis by gently sliding the I/O module into the slot until the lettered and numbered I/O cam latch begins to engage with the I/O cam pin, and then push the I/O cam latch all the way up to lock the module in place.
 . Recable the I/O module, as needed.
 
-== Step 3: Reboot the controller after I/O module replacement
+== Step 3: Reboot the BMC and controller after I/O module replacement
 
 [.lead]
-After you replace an I/O module, you must reboot the controller module.
+After you replace an I/O module, you must reboot the BMC and the controller module.
 
+. From the LOADER prompt, reboot the BMC: _sp reset_
 . From the LOADER prompt, reboot the node: _bye_
-. If your system is configured to support 10 GbE cluster interconnect and data connections on 40 GbE NICs or onboard ports, convert these ports to 10 GbE connections by using the nicadmin convert command from Maintenance mode.
+. If your system is configured to support 10 GbE cluster interconnect and data connections on 40 GbE NICs or onboard ports, convert these ports to 10 GbE connections by using the `nicadmin convert` command from Maintenance mode.
 +
 NOTE: Be sure to exit Maintenance mode after completing the conversion.
 


### PR DESCRIPTION
Due to Bug 1494308, the workaround for this issue is to reboot the BMC after an I/O module has been replaced or changed, clearing cached info in the BMC about the previous module.