### PR TITLE
State fans are hot-swappable

### DIFF
--- a/fas9500/fan_swap_out.adoc
+++ b/fas9500/fan_swap_out.adoc
@@ -13,6 +13,8 @@ To swap out a fan module without interrupting service, you must perform a specif
 
 IMPORTANT: You must replace the fan module within two minutes of removing it from the chassis. System airflow is disrupted and the controller module or modules shut down after two minutes to avoid overheating.
 
+You can use the following animation, illustration, and written steps to hot-swap a fan module.
+
 .Steps
 
 . If you are not already grounded, properly ground yourself.


### PR DESCRIPTION
Explicitly state that the fans are hot-swappable (this aligns with FAS 8700 documentation). Some RFPs need proof of how-swappable fans.