### PR TITLE
Update new-legacy-hardware-no-support.adoc

### DIFF
--- a/_include/new-legacy-hardware-no-support.adoc
+++ b/_include/new-legacy-hardware-no-support.adoc
@@ -4,6 +4,11 @@
 |===
 | System| Support discontinued from...
 a|
+* AFF A320
+* AFF A700s
+a|
+ONTAP 9.15.1
+a|
 * AFF A200
 * FAS2650
 * FAS2620


### PR DESCRIPTION
Added A320/A700s to systems discontinued from 9.15.1